### PR TITLE
ILP64 compatibility adjustment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Manifest.toml
 binary/
 binary/test.txt
+.vscode

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ CUDAdrv = "c5f51814-7f29-56b8-a69c-e4d8f6be1fde"
 CUDAnative = "be33ccc6-a3ff-5ff2-a52e-74243cff1e17"
 CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/clang/libmagma_api.jl
+++ b/src/clang/libmagma_api.jl
@@ -46,15 +46,15 @@ function magma_get_smlsize_divideconquer()
 end
 
 function magma_malloc(ptr_ptr, bytes)
-    ccall((:magma_malloc, libmagma), magma_int_t, (PtrOrCuPtr{magma_ptr}, Cint), ptr_ptr, bytes)
+    ccall((:magma_malloc, libmagma), magma_int_t, (PtrOrCuPtr{magma_ptr}, Int), ptr_ptr, bytes)
 end
 
 function magma_malloc_cpu(ptr_ptr, bytes)
-    ccall((:magma_malloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{Cvoid}}, Cint), ptr_ptr, bytes)
+    ccall((:magma_malloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{Cvoid}}, Int), ptr_ptr, bytes)
 end
 
 function magma_malloc_pinned(ptr_ptr, bytes)
-    ccall((:magma_malloc_pinned, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{Cvoid}}, Cint), ptr_ptr, bytes)
+    ccall((:magma_malloc_pinned, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{Cvoid}}, Int), ptr_ptr, bytes)
 end
 
 function magma_free_cpu(ptr)
@@ -62,91 +62,91 @@ function magma_free_cpu(ptr)
 end
 
 function magma_free_internal(ptr, func, file, line)
-    ccall((:magma_free_internal, libmagma), magma_int_t, (magma_ptr, Cstring, Cstring, Cint), ptr, func, file, line)
+    ccall((:magma_free_internal, libmagma), magma_int_t, (magma_ptr, Cstring, Cstring, Int), ptr, func, file, line)
 end
 
 function magma_free_pinned_internal(ptr, func, file, line)
-    ccall((:magma_free_pinned_internal, libmagma), magma_int_t, (PtrOrCuPtr{Cvoid}, Cstring, Cstring, Cint), ptr, func, file, line)
+    ccall((:magma_free_pinned_internal, libmagma), magma_int_t, (PtrOrCuPtr{Cvoid}, Cstring, Cstring, Int), ptr, func, file, line)
 end
 
 function magma_imalloc(ptr_ptr, n)
-    ccall((:magma_imalloc, libmagma), magma_int_t, (PtrOrCuPtr{magmaInt_ptr}, Cint), ptr_ptr, n)
+    ccall((:magma_imalloc, libmagma), magma_int_t, (PtrOrCuPtr{magmaInt_ptr}, Int), ptr_ptr, n)
 end
 
 function magma_index_malloc(ptr_ptr, n)
-    ccall((:magma_index_malloc, libmagma), magma_int_t, (PtrOrCuPtr{magmaIndex_ptr}, Cint), ptr_ptr, n)
+    ccall((:magma_index_malloc, libmagma), magma_int_t, (PtrOrCuPtr{magmaIndex_ptr}, Int), ptr_ptr, n)
 end
 
 function magma_uindex_malloc(ptr_ptr, n)
-    ccall((:magma_uindex_malloc, libmagma), magma_int_t, (PtrOrCuPtr{magmaUIndex_ptr}, Cint), ptr_ptr, n)
+    ccall((:magma_uindex_malloc, libmagma), magma_int_t, (PtrOrCuPtr{magmaUIndex_ptr}, Int), ptr_ptr, n)
 end
 
 function magma_smalloc(ptr_ptr, n)
-    ccall((:magma_smalloc, libmagma), magma_int_t, (PtrOrCuPtr{magmaFloat_ptr}, Cint), ptr_ptr, n)
+    ccall((:magma_smalloc, libmagma), magma_int_t, (PtrOrCuPtr{magmaFloat_ptr}, Int), ptr_ptr, n)
 end
 
 function magma_dmalloc(ptr_ptr, n)
-    ccall((:magma_dmalloc, libmagma), magma_int_t, (PtrOrCuPtr{magmaDouble_ptr}, Cint), ptr_ptr, n)
+    ccall((:magma_dmalloc, libmagma), magma_int_t, (PtrOrCuPtr{magmaDouble_ptr}, Int), ptr_ptr, n)
 end
 
 function magma_cmalloc(ptr_ptr, n)
-    ccall((:magma_cmalloc, libmagma), magma_int_t, (PtrOrCuPtr{magmaFloatComplex_ptr}, Cint), ptr_ptr, n)
+    ccall((:magma_cmalloc, libmagma), magma_int_t, (PtrOrCuPtr{magmaFloatComplex_ptr}, Int), ptr_ptr, n)
 end
 
 function magma_zmalloc(ptr_ptr, n)
-    ccall((:magma_zmalloc, libmagma), magma_int_t, (PtrOrCuPtr{magmaDoubleComplex_ptr}, Cint), ptr_ptr, n)
+    ccall((:magma_zmalloc, libmagma), magma_int_t, (PtrOrCuPtr{magmaDoubleComplex_ptr}, Int), ptr_ptr, n)
 end
 
 function magma_imalloc_cpu(ptr_ptr, n)
-    ccall((:magma_imalloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magma_int_t}}, Cint), ptr_ptr, n)
+    ccall((:magma_imalloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magma_int_t}}, Int), ptr_ptr, n)
 end
 
 function magma_index_malloc_cpu(ptr_ptr, n)
-    ccall((:magma_index_malloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magma_index_t}}, Cint), ptr_ptr, n)
+    ccall((:magma_index_malloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magma_index_t}}, Int), ptr_ptr, n)
 end
 
 function magma_uindex_malloc_cpu(ptr_ptr, n)
-    ccall((:magma_uindex_malloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magma_uindex_t}}, Cint), ptr_ptr, n)
+    ccall((:magma_uindex_malloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magma_uindex_t}}, Int), ptr_ptr, n)
 end
 
 function magma_smalloc_cpu(ptr_ptr, n)
-    ccall((:magma_smalloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{Cfloat}}, Cint), ptr_ptr, n)
+    ccall((:magma_smalloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{Cfloat}}, Int), ptr_ptr, n)
 end
 
 function magma_dmalloc_cpu(ptr_ptr, n)
-    ccall((:magma_dmalloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{Cdouble}}, Cint), ptr_ptr, n)
+    ccall((:magma_dmalloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{Cdouble}}, Int), ptr_ptr, n)
 end
 
 function magma_cmalloc_cpu(ptr_ptr, n)
-    ccall((:magma_cmalloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magmaFloatComplex}}, Cint), ptr_ptr, n)
+    ccall((:magma_cmalloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magmaFloatComplex}}, Int), ptr_ptr, n)
 end
 
 function magma_zmalloc_cpu(ptr_ptr, n)
-    ccall((:magma_zmalloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magmaDoubleComplex}}, Cint), ptr_ptr, n)
+    ccall((:magma_zmalloc_cpu, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magmaDoubleComplex}}, Int), ptr_ptr, n)
 end
 
 function magma_imalloc_pinned(ptr_ptr, n)
-    ccall((:magma_imalloc_pinned, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magma_int_t}}, Cint), ptr_ptr, n)
+    ccall((:magma_imalloc_pinned, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magma_int_t}}, Int), ptr_ptr, n)
 end
 
 function magma_index_malloc_pinned(ptr_ptr, n)
-    ccall((:magma_index_malloc_pinned, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magma_index_t}}, Cint), ptr_ptr, n)
+    ccall((:magma_index_malloc_pinned, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magma_index_t}}, Int), ptr_ptr, n)
 end
 
 function magma_smalloc_pinned(ptr_ptr, n)
-    ccall((:magma_smalloc_pinned, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{Cfloat}}, Cint), ptr_ptr, n)
+    ccall((:magma_smalloc_pinned, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{Cfloat}}, Int), ptr_ptr, n)
 end
 
 function magma_dmalloc_pinned(ptr_ptr, n)
-    ccall((:magma_dmalloc_pinned, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{Cdouble}}, Cint), ptr_ptr, n)
+    ccall((:magma_dmalloc_pinned, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{Cdouble}}, Int), ptr_ptr, n)
 end
 
 function magma_cmalloc_pinned(ptr_ptr, n)
-    ccall((:magma_cmalloc_pinned, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magmaFloatComplex}}, Cint), ptr_ptr, n)
+    ccall((:magma_cmalloc_pinned, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magmaFloatComplex}}, Int), ptr_ptr, n)
 end
 
 function magma_zmalloc_pinned(ptr_ptr, n)
-    ccall((:magma_zmalloc_pinned, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magmaDoubleComplex}}, Cint), ptr_ptr, n)
+    ccall((:magma_zmalloc_pinned, libmagma), magma_int_t, (PtrOrCuPtr{PtrOrCuPtr{magmaDoubleComplex}}, Int), ptr_ptr, n)
 end
 
 function magma_is_devptr(ptr)
@@ -174,7 +174,7 @@ function magma_setdevice(dev)
 end
 
 function magma_mem_size()
-    ccall((:magma_mem_size, libmagma), Cint, ())
+    ccall((:magma_mem_size, libmagma), Int, ())
 end
 
 function magma_getdevice_multiprocessor_count()
@@ -182,27 +182,27 @@ function magma_getdevice_multiprocessor_count()
 end
 
 function magma_getdevice_shmem_block()
-    ccall((:magma_getdevice_shmem_block, libmagma), Cint, ())
+    ccall((:magma_getdevice_shmem_block, libmagma), Int, ())
 end
 
 function magma_getdevice_shmem_multiprocessor()
-    ccall((:magma_getdevice_shmem_multiprocessor, libmagma), Cint, ())
+    ccall((:magma_getdevice_shmem_multiprocessor, libmagma), Int, ())
 end
 
 function magma_queue_create_internal(device, queue_ptr, func, file, line)
-    ccall((:magma_queue_create_internal, libmagma), Cvoid, (magma_device_t, PtrOrCuPtr{magma_queue_t}, Cstring, Cstring, Cint), device, queue_ptr, func, file, line)
+    ccall((:magma_queue_create_internal, libmagma), Cvoid, (magma_device_t, PtrOrCuPtr{magma_queue_t}, Cstring, Cstring, Int), device, queue_ptr, func, file, line)
 end
 
 # function magma_queue_create_from_cuda_internal(device, stream, cublas, cusparse, queue_ptr, func, file, line)
-#     ccall((:magma_queue_create_from_cuda_internal, libmagma), Cvoid, (magma_device_t, Cint, cublasHandle_t, Cint, PtrOrCuPtr{magma_queue_t}, Cstring, Cstring, Cint), device, stream, cublas, cusparse, queue_ptr, func, file, line)
+#     ccall((:magma_queue_create_from_cuda_internal, libmagma), Cvoid, (magma_device_t, Int, cublasHandle_t, Int, PtrOrCuPtr{magma_queue_t}, Cstring, Cstring, Int), device, stream, cublas, cusparse, queue_ptr, func, file, line)
 # end
 
 function magma_queue_destroy_internal(queue, func, file, line)
-    ccall((:magma_queue_destroy_internal, libmagma), Cvoid, (magma_queue_t, Cstring, Cstring, Cint), queue, func, file, line)
+    ccall((:magma_queue_destroy_internal, libmagma), Cvoid, (magma_queue_t, Cstring, Cstring, Int), queue, func, file, line)
 end
 
 function magma_queue_sync_internal(queue, func, file, line)
-    ccall((:magma_queue_sync_internal, libmagma), Cvoid, (magma_queue_t, Cstring, Cstring, Cint), queue, func, file, line)
+    ccall((:magma_queue_sync_internal, libmagma), Cvoid, (magma_queue_t, Cstring, Cstring, Int), queue, func, file, line)
 end
 
 function magma_queue_get_device(queue)
@@ -242,7 +242,7 @@ function magma_strerror(error)
 end
 
 function magma_strlcpy()
-    ccall((:magma_strlcpy, libmagma), Cint, ())
+    ccall((:magma_strlcpy, libmagma), Int, ())
 end
 
 function magma_ceildiv(x, y)
@@ -1055,15 +1055,15 @@ function magma_cunmtr_m(ngpu, side, uplo, trans, m, n, A, lda, tau, C, ldc, work
 end
 
 function magma_c_isnan(x)
-    ccall((:magma_c_isnan, libmagma), Cint, (magmaFloatComplex,), x)
+    ccall((:magma_c_isnan, libmagma), Int, (magmaFloatComplex,), x)
 end
 
 function magma_c_isinf(x)
-    ccall((:magma_c_isinf, libmagma), Cint, (magmaFloatComplex,), x)
+    ccall((:magma_c_isinf, libmagma), Int, (magmaFloatComplex,), x)
 end
 
 function magma_c_isnan_inf(x)
-    ccall((:magma_c_isnan_inf, libmagma), Cint, (magmaFloatComplex,), x)
+    ccall((:magma_c_isnan_inf, libmagma), Int, (magmaFloatComplex,), x)
 end
 
 function magma_cmake_lwork(lwork)
@@ -2300,246 +2300,246 @@ end
 
 
 function magma_setvector_internal(n, elemSize, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_setvector_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, elemSize, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_setvector_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, elemSize, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_getvector_internal(n, elemSize, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_getvector_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, elemSize, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_getvector_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, elemSize, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_copyvector_internal(n, elemSize, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_copyvector_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, elemSize, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_copyvector_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, elemSize, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_setvector_async_internal(n, elemSize, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_setvector_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, elemSize, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_setvector_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, elemSize, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_getvector_async_internal(n, elemSize, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_getvector_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, elemSize, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_getvector_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, elemSize, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_copyvector_async_internal(n, elemSize, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_copyvector_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, elemSize, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_copyvector_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, elemSize, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_setmatrix_internal(m, n, elemSize, hA_src, lda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_setmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, elemSize, hA_src, lda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_setmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, elemSize, hA_src, lda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_getmatrix_internal(m, n, elemSize, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
-    ccall((:magma_getmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, elemSize, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
+    ccall((:magma_getmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, elemSize, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
 end
 
 function magma_copymatrix_internal(m, n, elemSize, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_copymatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, elemSize, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_copymatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, elemSize, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_setmatrix_async_internal(m, n, elemSize, hA_src, lda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_setmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, elemSize, hA_src, lda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_setmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, elemSize, hA_src, lda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_getmatrix_async_internal(m, n, elemSize, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
-    ccall((:magma_getmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, elemSize, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
+    ccall((:magma_getmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, elemSize, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
 end
 
 function magma_copymatrix_async_internal(m, n, elemSize, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_copymatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, elemSize, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_copymatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, magma_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, elemSize, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_isetvector_internal(n, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_isetvector_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_isetvector_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_igetvector_internal(n, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_igetvector_internal, libmagma), Cvoid, (magma_int_t, magmaInt_const_ptr, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_igetvector_internal, libmagma), Cvoid, (magma_int_t, magmaInt_const_ptr, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_icopyvector_internal(n, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_icopyvector_internal, libmagma), Cvoid, (magma_int_t, magmaInt_const_ptr, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_icopyvector_internal, libmagma), Cvoid, (magma_int_t, magmaInt_const_ptr, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_isetvector_async_internal(n, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_isetvector_async_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_isetvector_async_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_igetvector_async_internal(n, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_igetvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaInt_const_ptr, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_igetvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaInt_const_ptr, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_icopyvector_async_internal(n, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_icopyvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaInt_const_ptr, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_icopyvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaInt_const_ptr, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_isetmatrix_internal(m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_isetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_isetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_igetmatrix_internal(m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
-    ccall((:magma_igetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaInt_const_ptr, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
+    ccall((:magma_igetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaInt_const_ptr, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
 end
 
 function magma_icopymatrix_internal(m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_icopymatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaInt_const_ptr, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_icopymatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaInt_const_ptr, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_isetmatrix_async_internal(m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_isetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_isetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_igetmatrix_async_internal(m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
-    ccall((:magma_igetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaInt_const_ptr, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
+    ccall((:magma_igetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaInt_const_ptr, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
 end
 
 function magma_icopymatrix_async_internal(m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_icopymatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaInt_const_ptr, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_icopymatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaInt_const_ptr, magma_int_t, magmaInt_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_index_setvector_internal(n, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_index_setvector_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_index_setvector_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_index_getvector_internal(n, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_index_getvector_internal, libmagma), Cvoid, (magma_int_t, magmaIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_index_getvector_internal, libmagma), Cvoid, (magma_int_t, magmaIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_index_copyvector_internal(n, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_index_copyvector_internal, libmagma), Cvoid, (magma_int_t, magmaIndex_const_ptr, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_index_copyvector_internal, libmagma), Cvoid, (magma_int_t, magmaIndex_const_ptr, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_index_setvector_async_internal(n, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_index_setvector_async_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_index_setvector_async_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_index_getvector_async_internal(n, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_index_getvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_index_getvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_index_copyvector_async_internal(n, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_index_copyvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaIndex_const_ptr, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_index_copyvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaIndex_const_ptr, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_uindex_setvector_internal(n, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_uindex_setvector_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_uindex_t}, magma_int_t, magmaUIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_uindex_setvector_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_uindex_t}, magma_int_t, magmaUIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_uindex_getvector_internal(n, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_uindex_getvector_internal, libmagma), Cvoid, (magma_int_t, magmaUIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_uindex_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_uindex_getvector_internal, libmagma), Cvoid, (magma_int_t, magmaUIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_uindex_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_uindex_copyvector_internal(n, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_uindex_copyvector_internal, libmagma), Cvoid, (magma_int_t, magmaUIndex_const_ptr, magma_int_t, magmaUIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_uindex_copyvector_internal, libmagma), Cvoid, (magma_int_t, magmaUIndex_const_ptr, magma_int_t, magmaUIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_uindex_setvector_async_internal(n, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_uindex_setvector_async_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_uindex_t}, magma_int_t, magmaUIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_uindex_setvector_async_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_uindex_t}, magma_int_t, magmaUIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_uindex_getvector_async_internal(n, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_uindex_getvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaUIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_uindex_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_uindex_getvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaUIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_uindex_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_uindex_copyvector_async_internal(n, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_uindex_copyvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaUIndex_const_ptr, magma_int_t, magmaUIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_uindex_copyvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaUIndex_const_ptr, magma_int_t, magmaUIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_index_setmatrix_internal(m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_index_setmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_index_setmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_index_getmatrix_internal(m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
-    ccall((:magma_index_getmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
+    ccall((:magma_index_getmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
 end
 
 function magma_index_copymatrix_internal(m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_index_copymatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaIndex_const_ptr, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_index_copymatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaIndex_const_ptr, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_index_setmatrix_async_internal(m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_index_setmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_index_setmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_index_getmatrix_async_internal(m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
-    ccall((:magma_index_getmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
+    ccall((:magma_index_getmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
 end
 
 function magma_index_copymatrix_async_internal(m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_index_copymatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaIndex_const_ptr, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_index_copymatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaIndex_const_ptr, magma_int_t, magmaIndex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
 end
 # Julia wrapper for header: magma_copy_v1.h
 # Automatically generated using Clang.jl
 
 
 function magma_setvector_v1_internal(n, elemSize, hx_src, incx, dy_dst, incy, func, file, line)
-    ccall((:magma_setvector_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_ptr, magma_int_t, Cstring, Cstring, Cint), n, elemSize, hx_src, incx, dy_dst, incy, func, file, line)
+    ccall((:magma_setvector_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_ptr, magma_int_t, Cstring, Cstring, Int), n, elemSize, hx_src, incx, dy_dst, incy, func, file, line)
 end
 
 function magma_getvector_v1_internal(n, elemSize, dx_src, incx, hy_dst, incy, func, file, line)
-    ccall((:magma_getvector_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, Cstring, Cstring, Cint), n, elemSize, dx_src, incx, hy_dst, incy, func, file, line)
+    ccall((:magma_getvector_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, Cstring, Cstring, Int), n, elemSize, dx_src, incx, hy_dst, incy, func, file, line)
 end
 
 function magma_copyvector_v1_internal(n, elemSize, dx_src, incx, dy_dst, incy, func, file, line)
-    ccall((:magma_copyvector_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, magma_ptr, magma_int_t, Cstring, Cstring, Cint), n, elemSize, dx_src, incx, dy_dst, incy, func, file, line)
+    ccall((:magma_copyvector_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, magma_ptr, magma_int_t, Cstring, Cstring, Int), n, elemSize, dx_src, incx, dy_dst, incy, func, file, line)
 end
 
 function magma_setmatrix_v1_internal(m, n, elemSize, hA_src, lda, dB_dst, lddb, func, file, line)
-    ccall((:magma_setmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_ptr, magma_int_t, Cstring, Cstring, Cint), m, n, elemSize, hA_src, lda, dB_dst, lddb, func, file, line)
+    ccall((:magma_setmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, magma_ptr, magma_int_t, Cstring, Cstring, Int), m, n, elemSize, hA_src, lda, dB_dst, lddb, func, file, line)
 end
 
 function magma_getmatrix_v1_internal(m, n, elemSize, dA_src, ldda, hB_dst, ldb, func, file, line)
-    ccall((:magma_getmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, Cstring, Cstring, Cint), m, n, elemSize, dA_src, ldda, hB_dst, ldb, func, file, line)
+    ccall((:magma_getmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, PtrOrCuPtr{Cvoid}, magma_int_t, Cstring, Cstring, Int), m, n, elemSize, dA_src, ldda, hB_dst, ldb, func, file, line)
 end
 
 function magma_copymatrix_v1_internal(m, n, elemSize, dA_src, ldda, dB_dst, lddb, func, file, line)
-    ccall((:magma_copymatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, magma_ptr, magma_int_t, Cstring, Cstring, Cint), m, n, elemSize, dA_src, ldda, dB_dst, lddb, func, file, line)
+    ccall((:magma_copymatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magma_int_t, magma_const_ptr, magma_int_t, magma_ptr, magma_int_t, Cstring, Cstring, Int), m, n, elemSize, dA_src, ldda, dB_dst, lddb, func, file, line)
 end
 
 function magma_isetvector_v1_internal(n, hx_src, incx, dy_dst, incy, func, file, line)
-    ccall((:magma_isetvector_v1_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magmaInt_ptr, magma_int_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, func, file, line)
+    ccall((:magma_isetvector_v1_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magmaInt_ptr, magma_int_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, func, file, line)
 end
 
 function magma_igetvector_v1_internal(n, dx_src, incx, hy_dst, incy, func, file, line)
-    ccall((:magma_igetvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaInt_const_ptr, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, func, file, line)
+    ccall((:magma_igetvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaInt_const_ptr, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, func, file, line)
 end
 
 function magma_icopyvector_v1_internal(n, dx_src, incx, dy_dst, incy, func, file, line)
-    ccall((:magma_icopyvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaInt_const_ptr, magma_int_t, magmaInt_ptr, magma_int_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, func, file, line)
+    ccall((:magma_icopyvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaInt_const_ptr, magma_int_t, magmaInt_ptr, magma_int_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, func, file, line)
 end
 
 function magma_isetmatrix_v1_internal(m, n, hA_src, lda, dB_dst, lddb, func, file, line)
-    ccall((:magma_isetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magmaInt_ptr, magma_int_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, func, file, line)
+    ccall((:magma_isetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, magmaInt_ptr, magma_int_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, func, file, line)
 end
 
 function magma_igetmatrix_v1_internal(m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
-    ccall((:magma_igetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaInt_const_ptr, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
+    ccall((:magma_igetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaInt_const_ptr, magma_int_t, PtrOrCuPtr{magma_int_t}, magma_int_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
 end
 
 function magma_icopymatrix_v1_internal(m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
-    ccall((:magma_icopymatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaInt_const_ptr, magma_int_t, magmaInt_ptr, magma_int_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
+    ccall((:magma_icopymatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaInt_const_ptr, magma_int_t, magmaInt_ptr, magma_int_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
 end
 
 function magma_index_setvector_v1_internal(n, hx_src, incx, dy_dst, incy, func, file, line)
-    ccall((:magma_index_setvector_v1_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magmaIndex_ptr, magma_int_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, func, file, line)
+    ccall((:magma_index_setvector_v1_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magmaIndex_ptr, magma_int_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, func, file, line)
 end
 
 function magma_index_getvector_v1_internal(n, dx_src, incx, hy_dst, incy, func, file, line)
-    ccall((:magma_index_getvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, func, file, line)
+    ccall((:magma_index_getvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, func, file, line)
 end
 
 function magma_index_copyvector_v1_internal(n, dx_src, incx, dy_dst, incy, func, file, line)
-    ccall((:magma_index_copyvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaIndex_const_ptr, magma_int_t, magmaIndex_ptr, magma_int_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, func, file, line)
+    ccall((:magma_index_copyvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaIndex_const_ptr, magma_int_t, magmaIndex_ptr, magma_int_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, func, file, line)
 end
 
 function magma_index_setmatrix_v1_internal(m, n, hA_src, lda, dB_dst, lddb, func, file, line)
-    ccall((:magma_index_setmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magmaIndex_ptr, magma_int_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, func, file, line)
+    ccall((:magma_index_setmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, magmaIndex_ptr, magma_int_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, func, file, line)
 end
 
 function magma_index_getmatrix_v1_internal(m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
-    ccall((:magma_index_getmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
+    ccall((:magma_index_getmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaIndex_const_ptr, magma_int_t, PtrOrCuPtr{magma_index_t}, magma_int_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
 end
 
 function magma_index_copymatrix_v1_internal(m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
-    ccall((:magma_index_copymatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaIndex_const_ptr, magma_int_t, magmaIndex_ptr, magma_int_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
+    ccall((:magma_index_copymatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaIndex_const_ptr, magma_int_t, magmaIndex_ptr, magma_int_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
 end
 # Julia wrapper for header: magma_cvbatched.h
 # Automatically generated using Clang.jl
@@ -3505,15 +3505,15 @@ function magma_dormtr_m(ngpu, side, uplo, trans, m, n, A, lda, tau, C, ldc, work
 end
 
 function magma_d_isnan(x)
-    ccall((:magma_d_isnan, libmagma), Cint, (Cdouble,), x)
+    ccall((:magma_d_isnan, libmagma), Int, (Cdouble,), x)
 end
 
 function magma_d_isinf(x)
-    ccall((:magma_d_isinf, libmagma), Cint, (Cdouble,), x)
+    ccall((:magma_d_isinf, libmagma), Int, (Cdouble,), x)
 end
 
 function magma_d_isnan_inf(x)
-    ccall((:magma_d_isnan_inf, libmagma), Cint, (Cdouble,), x)
+    ccall((:magma_d_isnan_inf, libmagma), Int, (Cdouble,), x)
 end
 
 function magma_dmake_lwork(lwork)
@@ -5772,15 +5772,15 @@ function magma_sormtr_m(ngpu, side, uplo, trans, m, n, A, lda, tau, C, ldc, work
 end
 
 function magma_s_isnan(x)
-    ccall((:magma_s_isnan, libmagma), Cint, (Cfloat,), x)
+    ccall((:magma_s_isnan, libmagma), Int, (Cfloat,), x)
 end
 
 function magma_s_isinf(x)
-    ccall((:magma_s_isinf, libmagma), Cint, (Cfloat,), x)
+    ccall((:magma_s_isinf, libmagma), Int, (Cfloat,), x)
 end
 
 function magma_s_isnan_inf(x)
-    ccall((:magma_s_isnan_inf, libmagma), Cint, (Cfloat,), x)
+    ccall((:magma_s_isnan_inf, libmagma), Int, (Cfloat,), x)
 end
 
 function magma_smake_lwork(lwork)
@@ -7121,7 +7121,7 @@ end
 
 
 function magma_queue_get_cuda_stream()
-    ccall((:magma_queue_get_cuda_stream, libmagma), Cint, ())
+    ccall((:magma_queue_get_cuda_stream, libmagma), Int, ())
 end
 
 # function magma_queue_get_cublas_handle(queue)
@@ -7129,7 +7129,7 @@ end
 # end
 
 function magma_queue_get_cusparse_handle()
-    ccall((:magma_queue_get_cusparse_handle, libmagma), Cint, ())
+    ccall((:magma_queue_get_cusparse_handle, libmagma), Int, ())
 end
 
 function magma_cabs(x)
@@ -7201,7 +7201,7 @@ function magma_storev_const(lapack_char)
 end
 
 function lapack_const_str(magma_const)
-    ccall((:lapack_const_str, libmagma), Cstring, (Cint,), magma_const)
+    ccall((:lapack_const_str, libmagma), Cstring, (Int,), magma_const)
 end
 
 function lapack_bool_const(magma_const)
@@ -7265,7 +7265,7 @@ function lapack_storev_const(magma_const)
 end
 
 function lapacke_const(magma_const)
-    ccall((:lapacke_const, libmagma), UInt8, (Cint,), magma_const)
+    ccall((:lapacke_const, libmagma), UInt8, (Int,), magma_const)
 end
 
 function lapacke_bool_const(magma_const)
@@ -8202,15 +8202,15 @@ function magma_zunmtr_m(ngpu, side, uplo, trans, m, n, A, lda, tau, C, ldc, work
 end
 
 function magma_z_isnan(x)
-    ccall((:magma_z_isnan, libmagma), Cint, (magmaDoubleComplex,), x)
+    ccall((:magma_z_isnan, libmagma), Int, (magmaDoubleComplex,), x)
 end
 
 function magma_z_isinf(x)
-    ccall((:magma_z_isinf, libmagma), Cint, (magmaDoubleComplex,), x)
+    ccall((:magma_z_isinf, libmagma), Int, (magmaDoubleComplex,), x)
 end
 
 function magma_z_isnan_inf(x)
-    ccall((:magma_z_isnan_inf, libmagma), Cint, (magmaDoubleComplex,), x)
+    ccall((:magma_z_isnan_inf, libmagma), Int, (magmaDoubleComplex,), x)
 end
 
 function magma_zmake_lwork(lwork)
@@ -9989,51 +9989,51 @@ function magmablas_ctrsm_work(side, uplo, transA, diag, m, n, alpha, dA, ldda, d
 end
 
 function magma_csetvector_internal(n, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_csetvector_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_csetvector_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_cgetvector_internal(n, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_cgetvector_internal, libmagma), Cvoid, (magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_cgetvector_internal, libmagma), Cvoid, (magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_ccopyvector_internal(n, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_ccopyvector_internal, libmagma), Cvoid, (magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_ccopyvector_internal, libmagma), Cvoid, (magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_csetvector_async_internal(n, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_csetvector_async_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_csetvector_async_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_cgetvector_async_internal(n, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_cgetvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_cgetvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_ccopyvector_async_internal(n, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_ccopyvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_ccopyvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_csetmatrix_internal(m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_csetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_csetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_cgetmatrix_internal(m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
-    ccall((:magma_cgetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
+    ccall((:magma_cgetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
 end
 
 function magma_ccopymatrix_internal(m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_ccopymatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_ccopymatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_csetmatrix_async_internal(m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_csetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_csetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_cgetmatrix_async_internal(m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
-    ccall((:magma_cgetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
+    ccall((:magma_cgetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
 end
 
 function magma_ccopymatrix_async_internal(m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_ccopymatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_ccopymatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, magmaFloatComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_icamax(n, dx, incx, queue)
@@ -10464,27 +10464,27 @@ function magmablas_ctrsm_work_v1(side, uplo, transA, diag, m, n, alpha, dA, ldda
 end
 
 function magma_csetvector_v1_internal(n, hx_src, incx, dy_dst, incy, func, file, line)
-    ccall((:magma_csetvector_v1_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magmaFloatComplex_ptr, magma_int_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, func, file, line)
+    ccall((:magma_csetvector_v1_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magmaFloatComplex_ptr, magma_int_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, func, file, line)
 end
 
 function magma_cgetvector_v1_internal(n, dx_src, incx, hy_dst, incy, func, file, line)
-    ccall((:magma_cgetvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, func, file, line)
+    ccall((:magma_cgetvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, func, file, line)
 end
 
 function magma_ccopyvector_v1_internal(n, dx_src, incx, dy_dst, incy, func, file, line)
-    ccall((:magma_ccopyvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, magmaFloatComplex_ptr, magma_int_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, func, file, line)
+    ccall((:magma_ccopyvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, magmaFloatComplex_ptr, magma_int_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, func, file, line)
 end
 
 function magma_csetmatrix_v1_internal(m, n, hA_src, lda, dB_dst, lddb, func, file, line)
-    ccall((:magma_csetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magmaFloatComplex_ptr, magma_int_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, func, file, line)
+    ccall((:magma_csetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, magmaFloatComplex_ptr, magma_int_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, func, file, line)
 end
 
 function magma_cgetmatrix_v1_internal(m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
-    ccall((:magma_cgetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
+    ccall((:magma_cgetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaFloatComplex}, magma_int_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
 end
 
 function magma_ccopymatrix_v1_internal(m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
-    ccall((:magma_ccopymatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, magmaFloatComplex_ptr, magma_int_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
+    ccall((:magma_ccopymatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloatComplex_const_ptr, magma_int_t, magmaFloatComplex_ptr, magma_int_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
 end
 
 function magma_icamax_v1(n, dx, incx)
@@ -10906,51 +10906,51 @@ function magmablas_dtrsm_work(side, uplo, transA, diag, m, n, alpha, dA, ldda, d
 end
 
 function magma_dsetvector_internal(n, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_dsetvector_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_dsetvector_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_dgetvector_internal(n, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_dgetvector_internal, libmagma), Cvoid, (magma_int_t, magmaDouble_const_ptr, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_dgetvector_internal, libmagma), Cvoid, (magma_int_t, magmaDouble_const_ptr, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_dcopyvector_internal(n, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_dcopyvector_internal, libmagma), Cvoid, (magma_int_t, magmaDouble_const_ptr, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_dcopyvector_internal, libmagma), Cvoid, (magma_int_t, magmaDouble_const_ptr, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_dsetvector_async_internal(n, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_dsetvector_async_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_dsetvector_async_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_dgetvector_async_internal(n, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_dgetvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaDouble_const_ptr, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_dgetvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaDouble_const_ptr, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_dcopyvector_async_internal(n, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_dcopyvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaDouble_const_ptr, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_dcopyvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaDouble_const_ptr, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_dsetmatrix_internal(m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_dsetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_dsetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_dgetmatrix_internal(m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
-    ccall((:magma_dgetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDouble_const_ptr, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
+    ccall((:magma_dgetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDouble_const_ptr, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
 end
 
 function magma_dcopymatrix_internal(m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_dcopymatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDouble_const_ptr, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_dcopymatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDouble_const_ptr, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_dsetmatrix_async_internal(m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_dsetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_dsetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_dgetmatrix_async_internal(m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
-    ccall((:magma_dgetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDouble_const_ptr, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
+    ccall((:magma_dgetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDouble_const_ptr, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
 end
 
 function magma_dcopymatrix_async_internal(m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_dcopymatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDouble_const_ptr, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_dcopymatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDouble_const_ptr, magma_int_t, magmaDouble_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_idamax(n, dx, incx, queue)
@@ -11321,27 +11321,27 @@ function magmablas_dtrsm_work_v1(side, uplo, transA, diag, m, n, alpha, dA, ldda
 end
 
 function magma_dsetvector_v1_internal(n, hx_src, incx, dy_dst, incy, func, file, line)
-    ccall((:magma_dsetvector_v1_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magmaDouble_ptr, magma_int_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, func, file, line)
+    ccall((:magma_dsetvector_v1_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magmaDouble_ptr, magma_int_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, func, file, line)
 end
 
 function magma_dgetvector_v1_internal(n, dx_src, incx, hy_dst, incy, func, file, line)
-    ccall((:magma_dgetvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaDouble_const_ptr, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, func, file, line)
+    ccall((:magma_dgetvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaDouble_const_ptr, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, func, file, line)
 end
 
 function magma_dcopyvector_v1_internal(n, dx_src, incx, dy_dst, incy, func, file, line)
-    ccall((:magma_dcopyvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaDouble_const_ptr, magma_int_t, magmaDouble_ptr, magma_int_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, func, file, line)
+    ccall((:magma_dcopyvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaDouble_const_ptr, magma_int_t, magmaDouble_ptr, magma_int_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, func, file, line)
 end
 
 function magma_dsetmatrix_v1_internal(m, n, hA_src, lda, dB_dst, lddb, func, file, line)
-    ccall((:magma_dsetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magmaDouble_ptr, magma_int_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, func, file, line)
+    ccall((:magma_dsetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, magmaDouble_ptr, magma_int_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, func, file, line)
 end
 
 function magma_dgetmatrix_v1_internal(m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
-    ccall((:magma_dgetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDouble_const_ptr, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
+    ccall((:magma_dgetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDouble_const_ptr, magma_int_t, PtrOrCuPtr{Cdouble}, magma_int_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
 end
 
 function magma_dcopymatrix_v1_internal(m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
-    ccall((:magma_dcopymatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDouble_const_ptr, magma_int_t, magmaDouble_ptr, magma_int_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
+    ccall((:magma_dcopymatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDouble_const_ptr, magma_int_t, magmaDouble_ptr, magma_int_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
 end
 
 function magma_idamax_v1(n, dx, incx)
@@ -11803,51 +11803,51 @@ function magmablas_strsm_work(side, uplo, transA, diag, m, n, alpha, dA, ldda, d
 end
 
 function magma_ssetvector_internal(n, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_ssetvector_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_ssetvector_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_sgetvector_internal(n, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_sgetvector_internal, libmagma), Cvoid, (magma_int_t, magmaFloat_const_ptr, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_sgetvector_internal, libmagma), Cvoid, (magma_int_t, magmaFloat_const_ptr, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_scopyvector_internal(n, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_scopyvector_internal, libmagma), Cvoid, (magma_int_t, magmaFloat_const_ptr, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_scopyvector_internal, libmagma), Cvoid, (magma_int_t, magmaFloat_const_ptr, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_ssetvector_async_internal(n, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_ssetvector_async_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_ssetvector_async_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_sgetvector_async_internal(n, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_sgetvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaFloat_const_ptr, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_sgetvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaFloat_const_ptr, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_scopyvector_async_internal(n, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_scopyvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaFloat_const_ptr, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_scopyvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaFloat_const_ptr, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_ssetmatrix_internal(m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_ssetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_ssetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_sgetmatrix_internal(m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
-    ccall((:magma_sgetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloat_const_ptr, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
+    ccall((:magma_sgetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloat_const_ptr, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
 end
 
 function magma_scopymatrix_internal(m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_scopymatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloat_const_ptr, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_scopymatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloat_const_ptr, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_ssetmatrix_async_internal(m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_ssetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_ssetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_sgetmatrix_async_internal(m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
-    ccall((:magma_sgetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloat_const_ptr, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
+    ccall((:magma_sgetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloat_const_ptr, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
 end
 
 function magma_scopymatrix_async_internal(m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_scopymatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloat_const_ptr, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_scopymatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloat_const_ptr, magma_int_t, magmaFloat_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_isamax(n, dx, incx, queue)
@@ -12218,27 +12218,27 @@ function magmablas_strsm_work_v1(side, uplo, transA, diag, m, n, alpha, dA, ldda
 end
 
 function magma_ssetvector_v1_internal(n, hx_src, incx, dy_dst, incy, func, file, line)
-    ccall((:magma_ssetvector_v1_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magmaFloat_ptr, magma_int_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, func, file, line)
+    ccall((:magma_ssetvector_v1_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magmaFloat_ptr, magma_int_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, func, file, line)
 end
 
 function magma_sgetvector_v1_internal(n, dx_src, incx, hy_dst, incy, func, file, line)
-    ccall((:magma_sgetvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaFloat_const_ptr, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, func, file, line)
+    ccall((:magma_sgetvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaFloat_const_ptr, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, func, file, line)
 end
 
 function magma_scopyvector_v1_internal(n, dx_src, incx, dy_dst, incy, func, file, line)
-    ccall((:magma_scopyvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaFloat_const_ptr, magma_int_t, magmaFloat_ptr, magma_int_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, func, file, line)
+    ccall((:magma_scopyvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaFloat_const_ptr, magma_int_t, magmaFloat_ptr, magma_int_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, func, file, line)
 end
 
 function magma_ssetmatrix_v1_internal(m, n, hA_src, lda, dB_dst, lddb, func, file, line)
-    ccall((:magma_ssetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magmaFloat_ptr, magma_int_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, func, file, line)
+    ccall((:magma_ssetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, magmaFloat_ptr, magma_int_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, func, file, line)
 end
 
 function magma_sgetmatrix_v1_internal(m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
-    ccall((:magma_sgetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloat_const_ptr, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
+    ccall((:magma_sgetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloat_const_ptr, magma_int_t, PtrOrCuPtr{Cfloat}, magma_int_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
 end
 
 function magma_scopymatrix_v1_internal(m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
-    ccall((:magma_scopymatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloat_const_ptr, magma_int_t, magmaFloat_ptr, magma_int_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
+    ccall((:magma_scopymatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaFloat_const_ptr, magma_int_t, magmaFloat_ptr, magma_int_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
 end
 
 function magma_isamax_v1(n, dx, incx)
@@ -12348,7 +12348,7 @@ end
 
 
 function magma_queue_create_v1_internal(queue_ptr, func, file, line)
-    ccall((:magma_queue_create_v1_internal, libmagma), Cvoid, (PtrOrCuPtr{magma_queue_t}, Cstring, Cstring, Cint), queue_ptr, func, file, line)
+    ccall((:magma_queue_create_v1_internal, libmagma), Cvoid, (PtrOrCuPtr{magma_queue_t}, Cstring, Cstring, Int), queue_ptr, func, file, line)
 end
 
 function magma_device_sync()
@@ -12682,51 +12682,51 @@ function magmablas_ztrsm_work(side, uplo, transA, diag, m, n, alpha, dA, ldda, d
 end
 
 function magma_zsetvector_internal(n, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_zsetvector_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_zsetvector_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_zgetvector_internal(n, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_zgetvector_internal, libmagma), Cvoid, (magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_zgetvector_internal, libmagma), Cvoid, (magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_zcopyvector_internal(n, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_zcopyvector_internal, libmagma), Cvoid, (magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_zcopyvector_internal, libmagma), Cvoid, (magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_zsetvector_async_internal(n, hx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_zsetvector_async_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_zsetvector_async_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_zgetvector_async_internal(n, dx_src, incx, hy_dst, incy, queue, func, file, line)
-    ccall((:magma_zgetvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
+    ccall((:magma_zgetvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, queue, func, file, line)
 end
 
 function magma_zcopyvector_async_internal(n, dx_src, incx, dy_dst, incy, queue, func, file, line)
-    ccall((:magma_zcopyvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
+    ccall((:magma_zcopyvector_async_internal, libmagma), Cvoid, (magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, queue, func, file, line)
 end
 
 function magma_zsetmatrix_internal(m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_zsetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_zsetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_zgetmatrix_internal(m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
-    ccall((:magma_zgetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
+    ccall((:magma_zgetmatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
 end
 
 function magma_zcopymatrix_internal(m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_zcopymatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_zcopymatrix_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_zsetmatrix_async_internal(m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_zsetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_zsetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_zgetmatrix_async_internal(m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
-    ccall((:magma_zgetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
+    ccall((:magma_zgetmatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, queue, func, file, line)
 end
 
 function magma_zcopymatrix_async_internal(m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
-    ccall((:magma_zcopymatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
+    ccall((:magma_zcopymatrix_async_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, magma_queue_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, queue, func, file, line)
 end
 
 function magma_izamax(n, dx, incx, queue)
@@ -13157,27 +13157,27 @@ function magmablas_ztrsm_work_v1(side, uplo, transA, diag, m, n, alpha, dA, ldda
 end
 
 function magma_zsetvector_v1_internal(n, hx_src, incx, dy_dst, incy, func, file, line)
-    ccall((:magma_zsetvector_v1_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, Cstring, Cstring, Cint), n, hx_src, incx, dy_dst, incy, func, file, line)
+    ccall((:magma_zsetvector_v1_internal, libmagma), Cvoid, (magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, Cstring, Cstring, Int), n, hx_src, incx, dy_dst, incy, func, file, line)
 end
 
 function magma_zgetvector_v1_internal(n, dx_src, incx, hy_dst, incy, func, file, line)
-    ccall((:magma_zgetvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, Cstring, Cstring, Cint), n, dx_src, incx, hy_dst, incy, func, file, line)
+    ccall((:magma_zgetvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, Cstring, Cstring, Int), n, dx_src, incx, hy_dst, incy, func, file, line)
 end
 
 function magma_zcopyvector_v1_internal(n, dx_src, incx, dy_dst, incy, func, file, line)
-    ccall((:magma_zcopyvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, Cstring, Cstring, Cint), n, dx_src, incx, dy_dst, incy, func, file, line)
+    ccall((:magma_zcopyvector_v1_internal, libmagma), Cvoid, (magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, Cstring, Cstring, Int), n, dx_src, incx, dy_dst, incy, func, file, line)
 end
 
 function magma_zsetmatrix_v1_internal(m, n, hA_src, lda, dB_dst, lddb, func, file, line)
-    ccall((:magma_zsetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, Cstring, Cstring, Cint), m, n, hA_src, lda, dB_dst, lddb, func, file, line)
+    ccall((:magma_zsetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, Cstring, Cstring, Int), m, n, hA_src, lda, dB_dst, lddb, func, file, line)
 end
 
 function magma_zgetmatrix_v1_internal(m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
-    ccall((:magma_zgetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
+    ccall((:magma_zgetmatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, PtrOrCuPtr{magmaDoubleComplex}, magma_int_t, Cstring, Cstring, Int), m, n, dA_src, ldda, hB_dst, ldb, func, file, line)
 end
 
 function magma_zcopymatrix_v1_internal(m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
-    ccall((:magma_zcopymatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, Cstring, Cstring, Cint), m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
+    ccall((:magma_zcopymatrix_v1_internal, libmagma), Cvoid, (magma_int_t, magma_int_t, magmaDoubleComplex_const_ptr, magma_int_t, magmaDoubleComplex_ptr, magma_int_t, Cstring, Cstring, Int), m, n, dA_src, ldda, dB_dst, lddb, func, file, line)
 end
 
 function magma_izamax_v1(n, dx, incx)

--- a/src/clang/libmagma_common.jl
+++ b/src/clang/libmagma_common.jl
@@ -12,9 +12,9 @@ const MAGMA_API = 2
 # Skipping MacroDefinition: magma_queue_sync ( queue ) magma_queue_sync_internal ( queue , __func__ , __FILE__ , __LINE__ )
 
 const MAX_THREADS_BLG = 256
-const magmaFloatComplex = Cint
+const magmaFloatComplex = Int
 
-@cenum magma_side_t::UInt32 begin
+@cenum magma_side_t::UInt begin
     MagmaLeft = 141
     MagmaRight = 142
     MagmaBothSides = 143
@@ -35,29 +35,29 @@ struct gbstrct_blg
     TAU::PtrOrCuPtr{magmaFloatComplex}
     E::PtrOrCuPtr{magmaFloatComplex}
     E_CPU::PtrOrCuPtr{magmaFloatComplex}
-    cores_num::Cint
-    locores_num::Cint
-    overlapQ1::Cint
-    usemulticpu::Cint
-    NB::Cint
-    NBTILES::Cint
-    N::Cint
-    NE::Cint
-    N_CPU::Cint
-    N_GPU::Cint
-    LDA::Cint
-    LDE::Cint
-    BAND::Cint
-    grsiz::Cint
-    Vblksiz::Cint
-    WANTZ::Cint
+    cores_num::Int
+    locores_num::Int
+    overlapQ1::Int
+    usemulticpu::Int
+    NB::Int
+    NBTILES::Int
+    N::Int
+    NE::Int
+    N_CPU::Int
+    N_GPU::Int
+    LDA::Int
+    LDE::Int
+    BAND::Int
+    grsiz::Int
+    Vblksiz::Int
+    WANTZ::Int
     SIDE::magma_side_t
     timeblg::PtrOrCuPtr{real_Double_t}
     timeaplQ::PtrOrCuPtr{real_Double_t}
-    ss_prog::PtrOrCuPtr{Cint}
+    ss_prog::PtrOrCuPtr{Int}
 end
 
-const magma_int_t = Cint
+const magma_int_t = Int
 const magmaFloatComplex_ptr = PtrOrCuPtr{magmaFloatComplex}
 const magma_queue = Cvoid
 const magma_queue_t = PtrOrCuPtr{magma_queue}
@@ -163,7 +163,7 @@ const MAGMA_ERR_CUSPARSE_INTERNAL_ERROR = -3007
 const MAGMA_ERR_CUSPARSE_MATRIX_TYPE_NOT_SUPPORTED = -3008
 const MAGMA_ERR_CUSPARSE_ZERO_PIVOT = -3009
 
-@cenum magma_bool_t::UInt32 begin
+@cenum magma_bool_t::UInt begin
     MagmaFalse = 0
     MagmaTrue = 1
 end
@@ -171,7 +171,7 @@ end
 
 const Magma2lapack_Min = MagmaFalse
 
-@cenum magma_storev_t::UInt32 begin
+@cenum magma_storev_t::UInt begin
     MagmaColumnwise = 401
     MagmaRowwise = 402
 end
@@ -207,12 +207,12 @@ const MagmaIVecStr = "IVec"
 const MagmaAllVecStr = "All"
 const MagmaSomeVecStr = "Some"
 const MagmaOverwriteVecStr = "Overwrite"
-const magma_index_t = Cint
-const magma_uindex_t = UInt32
-const magma_event_t = Cint
+const magma_index_t = Int
+const magma_uindex_t = UInt
+const magma_event_t = Int
 const magma_device_t = magma_int_t
 const magmaHalf = Int16
-const magmaDoubleComplex = Cint
+const magmaDoubleComplex = Int
 const magma_ptr = PtrOrCuPtr{Cvoid}
 const magmaInt_ptr = PtrOrCuPtr{magma_int_t}
 const magmaIndex_ptr = PtrOrCuPtr{magma_index_t}
@@ -229,19 +229,19 @@ const magmaFloatComplex_const_ptr = PtrOrCuPtr{magmaFloatComplex}
 const magmaDoubleComplex_const_ptr = PtrOrCuPtr{magmaDoubleComplex}
 const magmaHalf_const_ptr = PtrOrCuPtr{magmaHalf}
 
-@cenum magma_order_t::UInt32 begin
+@cenum magma_order_t::UInt begin
     MagmaRowMajor = 101
     MagmaColMajor = 102
 end
 
-@cenum magma_trans_t::UInt32 begin
+@cenum magma_trans_t::UInt begin
     MagmaNoTrans = 111
     MagmaTrans = 112
     MagmaConjTrans = 113
     Magma_ConjTrans = 113
 end
 
-@cenum magma_uplo_t::UInt32 begin
+@cenum magma_uplo_t::UInt begin
     MagmaUpper = 121
     MagmaLower = 122
     MagmaFull = 123
@@ -251,12 +251,12 @@ end
 
 const magma_type_t = magma_uplo_t
 
-@cenum magma_diag_t::UInt32 begin
+@cenum magma_diag_t::UInt begin
     MagmaNonUnit = 131
     MagmaUnit = 132
 end
 
-@cenum magma_norm_t::UInt32 begin
+@cenum magma_norm_t::UInt begin
     MagmaOneNorm = 171
     MagmaRealOneNorm = 172
     MagmaTwoNorm = 173
@@ -267,20 +267,20 @@ end
     MagmaRealMaxNorm = 178
 end
 
-@cenum magma_dist_t::UInt32 begin
+@cenum magma_dist_t::UInt begin
     MagmaDistUniform = 201
     MagmaDistSymmetric = 202
     MagmaDistNormal = 203
 end
 
-@cenum magma_sym_t::UInt32 begin
+@cenum magma_sym_t::UInt begin
     MagmaHermGeev = 241
     MagmaHermPoev = 242
     MagmaNonsymPosv = 243
     MagmaSymPosv = 244
 end
 
-@cenum magma_pack_t::UInt32 begin
+@cenum magma_pack_t::UInt begin
     MagmaNoPacking = 291
     MagmaPackSubdiag = 292
     MagmaPackSupdiag = 293
@@ -291,7 +291,7 @@ end
     MagmaPackAll = 298
 end
 
-@cenum magma_vec_t::UInt32 begin
+@cenum magma_vec_t::UInt begin
     MagmaNoVec = 301
     MagmaVec = 302
     MagmaIVec = 303
@@ -301,28 +301,28 @@ end
     MagmaBacktransVec = 307
 end
 
-@cenum magma_range_t::UInt32 begin
+@cenum magma_range_t::UInt begin
     MagmaRangeAll = 311
     MagmaRangeV = 312
     MagmaRangeI = 313
 end
 
-@cenum magma_vect_t::UInt32 begin
+@cenum magma_vect_t::UInt begin
     MagmaQ = 322
     MagmaP = 323
 end
 
-@cenum magma_direct_t::UInt32 begin
+@cenum magma_direct_t::UInt begin
     MagmaForward = 391
     MagmaBackward = 392
 end
 
-@cenum magma_mode_t::UInt32 begin
+@cenum magma_mode_t::UInt begin
     MagmaHybrid = 701
     MagmaNative = 702
 end
 
-@cenum magma_storage_t::UInt32 begin
+@cenum magma_storage_t::UInt begin
     Magma_CSR = 611
     Magma_ELLPACKT = 612
     Magma_ELL = 613
@@ -345,7 +345,7 @@ end
     Magma_CSR5 = 632
 end
 
-@cenum magma_solver_type::UInt32 begin
+@cenum magma_solver_type::UInt begin
     Magma_CG = 431
     Magma_CGMERGE = 432
     Magma_GMRES = 433
@@ -406,37 +406,37 @@ end
     Magma_ILUT = 511
 end
 
-@cenum magma_ortho_t::UInt32 begin
+@cenum magma_ortho_t::UInt begin
     Magma_CGSO = 561
     Magma_FUSED_CGSO = 562
     Magma_MGSO = 563
 end
 
-@cenum magma_location_t::UInt32 begin
+@cenum magma_location_t::UInt begin
     Magma_CPU = 571
     Magma_DEV = 572
 end
 
-@cenum magma_symmetry_t::UInt32 begin
+@cenum magma_symmetry_t::UInt begin
     Magma_GENERAL = 581
     Magma_SYMMETRIC = 582
 end
 
-@cenum magma_diagorder_t::UInt32 begin
+@cenum magma_diagorder_t::UInt begin
     Magma_ORDERED = 591
     Magma_DIAGFIRST = 592
     Magma_UNITY = 593
     Magma_VALUE = 594
 end
 
-@cenum magma_precision::UInt32 begin
+@cenum magma_precision::UInt begin
     Magma_DCOMPLEX = 501
     Magma_FCOMPLEX = 502
     Magma_DOUBLE = 503
     Magma_FLOAT = 504
 end
 
-@cenum magma_scale_t::UInt32 begin
+@cenum magma_scale_t::UInt begin
     Magma_NOSCALE = 511
     Magma_UNITROW = 512
     Magma_UNITDIAG = 513
@@ -445,7 +445,7 @@ end
     Magma_UNITDIAGCOL = 516
 end
 
-@cenum magma_operation_t::UInt32 begin
+@cenum magma_operation_t::UInt begin
     Magma_SOLVE = 801
     Magma_SETUPSOLVE = 802
     Magma_APPLYSOLVE = 803
@@ -458,7 +458,7 @@ end
     Magma_SPMV = 810
 end
 
-@cenum magma_refinement_t::UInt32 begin
+@cenum magma_refinement_t::UInt begin
     Magma_PREC_SS = 900
     Magma_PREC_SST = 901
     Magma_PREC_HS = 902
@@ -485,7 +485,7 @@ end
     Magma_PREC_HD = 930
 end
 
-@cenum magma_mp_type_t::UInt32 begin
+@cenum magma_mp_type_t::UInt begin
     Magma_MP_BASE_SS = 950
     Magma_MP_BASE_DD = 951
     Magma_MP_BASE_XHS = 952

--- a/src/dense/linearsystemsolver.jl
+++ b/src/dense/linearsystemsolver.jl
@@ -22,9 +22,9 @@ for type in magmaTypeList
         #       INTEGER            INFO, LDA, LDB, LWORK, M, N, NRHS
         function magma_gels!(trans::magma_trans_t, A::CuArray{$elty}, B::CuArray{$elty})
             m, n  = size(A)
-            info  = Ref{Cint}()
+            info  = Ref{Int}()
             work  = Vector{$elty}(undef, 1)
-            lwork = Cint(-1)
+            lwork = Int(-1)
 
             for i = 1:2  # first call returns lwork as work[1]
                 func = eval(@magmafunc_gpu($gels))
@@ -33,10 +33,10 @@ for type in magmaTypeList
                     A, max(1,stride(A,2)), B, max(1,stride(B,2)),
                     work, lwork, info
                 )
-                # ccall((@magmafunc_gpu($gels), libmagma), Cint,
-                #       (Cint, Cint, Cint, Cint,
-                #        PtrOrCuPtr{$elty}, Cint, PtrOrCuPtr{$elty}, Cint,
-                #        Ptr{$elty}, Cint, Ptr{Cint}),
+                # ccall((@magmafunc_gpu($gels), libmagma), Int,
+                #       (Int, Int, Int, Int,
+                #        PtrOrCuPtr{$elty}, Int, PtrOrCuPtr{$elty}, Int,
+                #        Ptr{$elty}, Int, Ptr{Int}),
                 #       MagmaNoTrans, m, n, size(B,2),
                 #       A, max(1,stride(A,2)), B, max(1,stride(B,2)),
                 #       work, lwork, info)
@@ -61,9 +61,9 @@ for type in magmaTypeList
         end
         function magma_gels!(trans::magma_trans_t, A::Array{$elty}, B::Array{$elty})
             m, n  = size(A)
-            info  = Ref{Cint}()
+            info  = Ref{Int}()
             work  = Vector{$elty}(undef, 1)
-            lwork = Cint(-1)
+            lwork = Int(-1)
 
             for i = 1:2  # first call returns lwork as work[1]
                 func = eval(@magmafunc($gels))
@@ -72,10 +72,10 @@ for type in magmaTypeList
                     A, max(1,stride(A,2)), B, max(1,stride(B,2)),
                     work, lwork, info
                 )
-                # ccall((@magmafunc($gels), libmagma), Cint,
-                #       (Cint, Cint, Cint, Cint,
-                #        PtrOrCuPtr{$elty}, Cint, PtrOrCuPtr{$elty}, Cint,
-                #        Ptr{$elty}, Cint, Ptr{Cint}),
+                # ccall((@magmafunc($gels), libmagma), Int,
+                #       (Int, Int, Int, Int,
+                #        PtrOrCuPtr{$elty}, Int, PtrOrCuPtr{$elty}, Int,
+                #        Ptr{$elty}, Int, Ptr{Int}),
                 #       MagmaNoTrans, m, n, size(B,2),
                 #       A, max(1,stride(A,2)), B, max(1,stride(B,2)),
                 #       work, lwork, info)
@@ -121,8 +121,8 @@ for type in magmaTypeList
             # end
             lda  = max(1,stride(A,2))
             ldb  = max(1,stride(B,2))
-            ipiv = similar(Matrix(A), Int32, n)
-            info = Ref{Cint}()
+            ipiv = similar(Matrix(A), Int, n)
+            info = Ref{Int}()
 
             func = eval(@magmafunc_gpu($gesv))
             func(
@@ -130,10 +130,10 @@ for type in magmaTypeList
                 A, lda, ipiv,
                 B, ldb, info
             )
-            # ccall((@magmafunc_gpu($gesv), libmagma), Cint,
-            #       (Cint, Cint,
-            #        PtrOrCuPtr{$elty}, Cint, Ptr{Cint},
-            #        PtrOrCuPtr{$elty}, Cint, Ptr{Cint}),
+            # ccall((@magmafunc_gpu($gesv), libmagma), Int,
+            #       (Int, Int,
+            #        PtrOrCuPtr{$elty}, Int, Ptr{Int},
+            #        PtrOrCuPtr{$elty}, Int, Ptr{Int}),
             #        n, size(B,2),
             #        A, lda, ipiv,
             #        B, ldb, info)
@@ -151,8 +151,8 @@ for type in magmaTypeList
             # end
             lda  = max(1,stride(A,2))
             ldb  = max(1,stride(B,2))
-            ipiv = similar(Matrix(A), Int32, n)
-            info = Ref{Cint}()
+            ipiv = similar(Matrix(A), Int, n)
+            info = Ref{Int}()
 
             func = eval(@magmafunc($gesv))
             func(
@@ -160,10 +160,10 @@ for type in magmaTypeList
                 A, lda, ipiv,
                 B, ldb, info
             )
-            # ccall((@magmafunc($gesv), libmagma), Cint,
-            #       (Cint, Cint,
-            #        PtrOrCuPtr{$elty}, Cint, Ptr{Cint},
-            #        PtrOrCuPtr{$elty}, Cint, Ptr{Cint}),
+            # ccall((@magmafunc($gesv), libmagma), Int,
+            #       (Int, Int,
+            #        PtrOrCuPtr{$elty}, Int, Ptr{Int},
+            #        PtrOrCuPtr{$elty}, Int, Ptr{Int}),
             #        n, size(B,2),
             #        A, lda, ipiv,
             #        B, ldb, info)
@@ -191,7 +191,7 @@ for type in magmaTypeList
             nrhs = size(B, 2)
             lda  = max(1,stride(A,2))
             ldb  = max(1,stride(B,2))
-            info = Ref{Cint}()
+            info = Ref{Int}()
             
             func = eval(@magmafunc_gpu($getrs))
             func(trans, n, nrhs, A, lda, ipiv, B, ldb, info)
@@ -227,11 +227,11 @@ for type in magmaTypeList
             nb    = func_nb(n)
             lwork = ceil(Int, real(n * nb))
             work  = cu(Vector{$elty}(undef, max(1, lwork)))
-            info  = Ref{Cint}()
+            info  = Ref{Int}()
             # for i = 1:2  # first call returns lwork as work[1]
                 # ccall((@magmafunc_gpu($getri), libmagma), Cvoid, # ! MAGMA has no native cpu interface for getri
-                #       (Ref{Cint}, PtrOrCuPtr{$elty}, Ref{Cint}, PtrOrCuPtr{Cint},
-                #        PtrOrCuPtr{$elty}, Ref{Cint}, PtrOrCuPtr{Cint}),
+                #       (Ref{Int}, PtrOrCuPtr{$elty}, Ref{Int}, PtrOrCuPtr{Int},
+                #        PtrOrCuPtr{$elty}, Ref{Int}, PtrOrCuPtr{Int}),
                 #       n, A, lda, ipiv, work, lwork, info)
                 # # chkmagmaerror(info[])
             func = eval(@magmafunc_gpu($getri))
@@ -252,8 +252,8 @@ for type in magmaTypeList
             chkstride1(A)
             m, n = size(A)
             lda = max(1, stride(A, 2))
-            ipiv = similar(A, Cint, min(m, n))
-            info = Ref{Cint}()
+            ipiv = similar(A, Int, min(m, n))
+            info = Ref{Int}()
             func = eval(@magmafunc($getrf))
             func(m, n, A, lda, ipiv, info)
             A, ipiv, info[]

--- a/src/dense/svd.jl
+++ b/src/dense/svd.jl
@@ -40,7 +40,7 @@ for (gesvd, gesdd, elty, relty) in    ((:sgesvd, :sgesdd, :Float32, :Float32),
                 work    = Vector{$elty}(undef, 1)
 
                 lwork   = -1
-                info    = Ref{Cint}()
+                info    = Ref{Int}()
 
                 jobu_magma      = char_to_magmaInt(jobu)
                 jobvt_magma     = char_to_magmaInt(jobvt)
@@ -56,15 +56,15 @@ for (gesvd, gesdd, elty, relty) in    ((:sgesvd, :sgesdd, :Float32, :Float32),
                         VT, ldvt,
                         work, lwork,
                         info)
-                    # ccall((@magmafunc($gesvd), libmagma), Cint,
-                    #         (Cint, Cint,
-                    #         Cint, Cint,
-                    #         Ptr{$elty}, Cint,
+                    # ccall((@magmafunc($gesvd), libmagma), Int,
+                    #         (Int, Int,
+                    #         Int, Int,
+                    #         Ptr{$elty}, Int,
                     #         Ptr{$relty},
-                    #         Ptr{$elty}, Cint,
-                    #         Ptr{$elty}, Cint,
-                    #         Ptr{$elty}, Cint,
-                    #         Ptr{Cint}),
+                    #         Ptr{$elty}, Int,
+                    #         Ptr{$elty}, Int,
+                    #         Ptr{$elty}, Int,
+                    #         Ptr{Int}),
                     #         jobu_magma, jobvt_magma,
                     #         m, n,
                     #         A, lda,
@@ -133,9 +133,9 @@ for (gesvd, gesdd, elty, relty) in    ((:sgesvd, :sgesdd, :Float32, :Float32),
 
 
                 work    = Vector{$elty}(undef, 1)
-                lwork   = Cint(-1)
-                iwork = Vector{Cint}(undef, 8*minmn)
-                info    = Ref{Cint}()
+                lwork   = Int(-1)
+                iwork = Vector{Int}(undef, 8*minmn)
+                info    = Ref{Int}()
 
                 job_magma      = char_to_magmaInt(job)
 
@@ -151,15 +151,15 @@ for (gesvd, gesdd, elty, relty) in    ((:sgesvd, :sgesdd, :Float32, :Float32),
                         work, lwork,
                         iwork, info
                     )
-                    # ccall((@magmafunc($gesdd), libmagma), Cint,
-                    #         (Cint,
-                    #         Cint, Cint,
-                    #         Ptr{$elty}, Cint,
+                    # ccall((@magmafunc($gesdd), libmagma), Int,
+                    #         (Int,
+                    #         Int, Int,
+                    #         Ptr{$elty}, Int,
                     #         Ptr{$relty},
-                    #         Ptr{$elty}, Cint,
-                    #         Ptr{$elty}, Cint,
-                    #         Ptr{$elty}, Cint,
-                    #         Ptr{Cint}, Ptr{Cint}),
+                    #         Ptr{$elty}, Int,
+                    #         Ptr{$elty}, Int,
+                    #         Ptr{$elty}, Int,
+                    #         Ptr{Int}, Ptr{Int}),
 
                     #         job_magma,
                     #         m, n,
@@ -170,7 +170,7 @@ for (gesvd, gesdd, elty, relty) in    ((:sgesvd, :sgesdd, :Float32, :Float32),
                     #         work, lwork,
                     #         iwork, info)
                     if i == 1
-                        lwork = ceil(Cint, nextfloat(real(work[1])))
+                        lwork = ceil(Int, nextfloat(real(work[1])))
                         resize!(work, lwork)
                     end
                 end
@@ -238,7 +238,7 @@ for (gesvd, gesdd, elty, relty) in    ((:cgesvd, :cgesdd, :ComplexF32, :Float32)
 
                 rwork = Vector{$relty}(undef, 5minmn)
                 lwork   = -1
-                info    = Ref{Cint}()
+                info    = Ref{Int}()
 
                 jobu_magma      = char_to_magmaInt(jobu)
                 jobvt_magma     = char_to_magmaInt(jobvt)
@@ -258,15 +258,15 @@ for (gesvd, gesdd, elty, relty) in    ((:cgesvd, :cgesdd, :ComplexF32, :Float32)
 
                         info
                     )
-                    # ccall((@magmafunc($gesvd), libmagma), Cint,
-                    #     (Cint, Cint,
-                    #     Cint, Cint,
-                    #     Ptr{$elty}, Cint,
+                    # ccall((@magmafunc($gesvd), libmagma), Int,
+                    #     (Int, Int,
+                    #     Int, Int,
+                    #     Ptr{$elty}, Int,
                     #     Ptr{$relty},
-                    #     Ptr{$elty}, Cint,
-                    #     Ptr{$elty}, Cint,
-                    #     Ptr{$elty}, Cint, Ptr{$relty},
-                    #     Ptr{Cint}),
+                    #     Ptr{$elty}, Int,
+                    #     Ptr{$elty}, Int,
+                    #     Ptr{$elty}, Int, Ptr{$relty},
+                    #     Ptr{Int}),
                     #     jobu_magma, jobvt_magma,
                     #     m, n,
                     #     A, lda,
@@ -338,11 +338,11 @@ for (gesvd, gesdd, elty, relty) in    ((:cgesvd, :cgesdd, :ComplexF32, :Float32)
 
 
             work    = Vector{$elty}(undef, 1)
-            lwork   = Cint(-1)
+            lwork   = Int(-1)
             rwork = Vector{$relty}(undef, job == 'N' ?
                 7*minmn : minmn*max(5*minmn+7, 2*max(m,n)+2*minmn+1))
-            iwork = Vector{Cint}(undef, 8*minmn)
-            info    = Ref{Cint}()
+            iwork = Vector{Int}(undef, 8*minmn)
+            info    = Ref{Int}()
 
             job_magma      = char_to_magmaInt(job)
 
@@ -359,16 +359,16 @@ for (gesvd, gesdd, elty, relty) in    ((:cgesvd, :cgesdd, :ComplexF32, :Float32)
                     rwork,
                     iwork, info
                 )
-                # ccall((@magmafunc($gesdd), libmagma), Cint,
-                #         (Cint,
-                #         Cint, Cint,
-                #         Ptr{$elty}, Cint,
+                # ccall((@magmafunc($gesdd), libmagma), Int,
+                #         (Int,
+                #         Int, Int,
+                #         Ptr{$elty}, Int,
                 #         Ptr{$relty},
-                #         Ptr{$elty}, Cint,
-                #         Ptr{$elty}, Cint,
-                #         Ptr{$elty}, Cint,
+                #         Ptr{$elty}, Int,
+                #         Ptr{$elty}, Int,
+                #         Ptr{$elty}, Int,
                 #         Ptr{$relty},
-                #         Ptr{Cint}, Ptr{Cint}),
+                #         Ptr{Int}, Ptr{Int}),
 
                 #         job_magma,
                 #         m, n,
@@ -380,7 +380,7 @@ for (gesvd, gesdd, elty, relty) in    ((:cgesvd, :cgesdd, :ComplexF32, :Float32)
                 #         rwork,
                 #         iwork, info)
                 if i == 1
-                    lwork = ceil(Cint, nextfloat(real(work[1])))
+                    lwork = ceil(Int, nextfloat(real(work[1])))
                     resize!(work, lwork)
                 end
             end
@@ -442,8 +442,8 @@ for (gebrd, elty, relty) in    ((:sgebrd, :Float32, :Float32),
                 taup = similar(A, $elty, minmn)
 
                 work    = Vector{$elty}(undef, 1)
-                lwork   = Cint(-1)
-                info = Ref{Cint}()
+                lwork   = Int(-1)
+                info = Ref{Int}()
 
                 for i in 1:2 # first call returns lwork as work[1]
                     func = eval(@magmafunc($gebrd))
@@ -452,16 +452,16 @@ for (gebrd, elty, relty) in    ((:sgebrd, :Float32, :Float32),
                         d, e, tauq, taup,
                         work, lwork, info
                     )
-                    # ccall((@magmafunc($gebrd), libmagma), Cint,
-                    #     (Cint, Cint, Ptr{$elty}, Cint,
+                    # ccall((@magmafunc($gebrd), libmagma), Int,
+                    #     (Int, Int, Ptr{$elty}, Int,
                     #     Ptr{$relty}, Ptr{$relty}, Ptr{$elty}, Ptr{$elty},
-                    #     Ptr{$elty}, Cint, Ptr{Cint}),
+                    #     Ptr{$elty}, Int, Ptr{Int}),
 
                     #     m, n, A, lda,
                     #     d, e, tauq, taup,
                     #     work, lwork, info)
                     if i == 1 
-                        lwork = ceil(Cint, nextfloat(real(work[1])))
+                        lwork = ceil(Int, nextfloat(real(work[1])))
                         resize!(work, lwork)
                     end
                 end

--- a/test/dense/linearsystemsolver.jl
+++ b/test/dense/linearsystemsolver.jl
@@ -114,7 +114,7 @@ end
             magma_finalize()
             # println("A ≈ Atest: ", A≈Atest)
             # println("ipiv", ipiv ≈ ipivtest)
-            @test_broken B ≈ Btest
+            @test B ≈ Btest
         end
     end
 end


### PR DESCRIPTION
For the compatibility with ILP64 OpenBLAS used in Julia, I made some adjustments, changing all the `Int32` and `Cint` to `Int`.