### PR TITLE
convert all arrays in test

### DIFF
--- a/test/dense/linearsystemsolver.jl
+++ b/test/dense/linearsystemsolver.jl
@@ -24,7 +24,7 @@ import LinearAlgebra.LAPACK: gels!, gesv!, getrs!, getri!
 
     # if S is approximately equal to s, we defined then it's alright
     for i in 1:length(result)
-        @test result[i] ≈ right_answer[i]
+        @test Array(result[i]) ≈ Array(right_answer[i])
     end
 
 end
@@ -52,7 +52,7 @@ end
 
     # if S is approximately equal to s, we defined then it's alright
     for i in 1:length(result)
-        @test result[i] ≈ right_answer[i]
+        @test Array(result[i]) ≈ Array(right_answer[i])
     end
 
 end
@@ -81,7 +81,7 @@ end
             B = magma_getri!(B, ipivB)
             magma_finalize()
             
-            @test A ≈ B
+            @test Array(A) ≈ Array(B)
         end
     end
 end
@@ -114,7 +114,7 @@ end
             magma_finalize()
             # println("A ≈ Atest: ", A≈Atest)
             # println("ipiv", ipiv ≈ ipivtest)
-            @test B ≈ Btest
+            @test Array(B) ≈ Array(Btest)
         end
     end
 end
@@ -131,7 +131,7 @@ end
             magma_finalize()
             B, ipivB,infoB= LAPACK.getrf!(B)
 
-            @test A ≈ B
+            @test Array(A) ≈ Array(B)
             @test ipiv ≈ ipivB
         end
     end


### PR DESCRIPTION
After updating to `CUDA10.2`, things changed a little bit; just as @pnavaro mentioned before in [another PR](https://github.com/Roger-luo/MAGMA.jl/pull/38), the `≈` operator between `CuArray` and `Array` has not been implemented yet.

Therefore, I just convert all the arrays on both sides of every `≈`in test files to `Array` with brute force.